### PR TITLE
Assign default edit role to lcm to support kubernetes 1.9 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ FfDL is a collaboration platform for:
 There are multiple installation paths for installing FfDL locally ("1-click-install") or
 into an existing Kubernetes cluster.
 
+> Note: If your Kubernetes Cluster version is 1.7 or below, please go to the [values.yaml](values.yaml) and change `k8s_1dot8_or_above` to **false**.
+
 ### 1.1 Installation using Vagrant
 
 This is the simplest and recommended option for local testing. The following commands will automatically
@@ -147,6 +149,8 @@ kubectl get pods --all-namespaces | grep tiller-deploy
 ```
 
 2. Now let's install all the necessary FfDL components using helm install.
+> Note: If your Kubernetes Cluster version is 1.7 or below, please go to the [values.yaml](values.yaml) and change `k8s_1dot8_or_above` to **false**.
+
 ``` shell
 helm install .
 ```

--- a/templates/services/lcm-deployment.yml
+++ b/templates/services/lcm-deployment.yml
@@ -34,6 +34,8 @@ spec:
               key: DLAAS_ETCD_CERT,
               path: etcd/etcd.cert
             }]
+      serviceAccount: {{.Values.docker.image_prefix}}lcm
+      serviceAccountName: {{.Values.docker.image_prefix}}lcm
       containers:
       - name: ffdl-lcm-container
         image: {{.Values.docker.registry}}/{{.Values.docker.namespace}}/{{.Values.docker.image_prefix}}lcm:{{.Values.trainer.version}}

--- a/templates/services/lcm-deployment.yml
+++ b/templates/services/lcm-deployment.yml
@@ -34,8 +34,10 @@ spec:
               key: DLAAS_ETCD_CERT,
               path: etcd/etcd.cert
             }]
+{{ if .Values.k8s_1dot8_or_above }}
       serviceAccount: {{.Values.docker.image_prefix}}lcm
       serviceAccountName: {{.Values.docker.image_prefix}}lcm
+{{ end }}
       containers:
       - name: ffdl-lcm-container
         image: {{.Values.docker.registry}}/{{.Values.docker.namespace}}/{{.Values.docker.image_prefix}}lcm:{{.Values.trainer.version}}

--- a/templates/services/lcm-rbac.yml
+++ b/templates/services/lcm-rbac.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Values.docker.image_prefix}}lcm
+  namespace: {{.Values.namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{.Values.docker.image_prefix}}lcm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - kind: ServiceAccount
+    name: {{.Values.docker.image_prefix}}lcm
+    namespace: {{.Values.namespace}}

--- a/templates/services/lcm-rbac.yml
+++ b/templates/services/lcm-rbac.yml
@@ -1,3 +1,4 @@
+{{ if .Values.k8s_1dot8_or_above }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -16,3 +17,4 @@ subjects:
   - kind: ServiceAccount
     name: {{.Values.docker.image_prefix}}lcm
     namespace: {{.Values.namespace}}
+{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-namespace: test
+namespace: default
 env: dev
 services:
   expose_node_port: true

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,6 @@
 namespace: default
 env: dev
+k8s_1dot8_or_above: true
 services:
   expose_node_port: true
 docker:


### PR DESCRIPTION
From Kubernetes 1.9 and above, the default service account is not allow to view and consume cluster resources. Thus, we will assign the default edit role to LCM, so LCM can view and distribute resources to the corresponding learners.

This PR also fixes #21 