### PR TITLE
Update helmignore to avoid oversized helm configmap

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -15,3 +15,5 @@ Makefile
 README.md
 .venv
 tmp
+docs/
+metrics/


### PR DESCRIPTION
Since oversized helm chart may fail helm to create some ConfigMap, I updated the `.helmignore` file with docs and metrics directory to avoid helm chart ConfigMap being oversized. 