### PR TITLE
Update TensorFlow example to a stable version

### DIFF
--- a/etc/examples/tf-model/manifest.yml
+++ b/etc/examples/tf-model/manifest.yml
@@ -21,7 +21,7 @@ data_stores:
 
 framework:
   name: tensorflow
-  version: "latest"
+  version: "1.5.0"
   command: >
     python mnist_with_summaries.py
     --train_images_file ${DATA_DIR}/train-images-idx3-ubyte.gz


### PR DESCRIPTION
Recently TensorFlow's latest image is updated to 1.6.0. Our TensorFlow example has some deprecated library in 1.6.0 and it may cause potential failure when executing training layer on Kubernetes 1.9.3 using CPU. Thus, move the TensorFlow version back to the stable 1.5.0. version which is tested on Minikube, Vagrant, IBM Cloud, ICP, and Kubeadm. 