### PR TITLE
Temporary fix for CI with k8s 1.9.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ install-minikube-in-ci:
 		chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 	@curl -s -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && \
 		chmod +x minikube && sudo mv minikube /usr/local/bin/
-	@sudo minikube start --vm-driver=none
+	@sudo minikube start --vm-driver=none --feature-gates=ReadOnlyAPIDataVolumes=false
 	@minikube update-context
 	@JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; \
 		until kubectl get nodes -o jsonpath="$$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ helm delete $(helm list | grep ffdl | awk '{print $1}' | head -n 1)
 
 * To remove FfDL on your Cluster, simply run `make undeploy`
 
-* Since the current implementation of FfDL will need write access for its mounted volume, if you are using Kubernetes 1.9.4 or above, please modify the feature gate `ReadOnlyAPIDataVolumes=false`. 
+* Since the current implementation of FfDL needs write access for its mounted volume, if you are using Kubernetes 1.9.4 or above, please modify the feature gate `ReadOnlyAPIDataVolumes=false`. 
 
 ## 9. References
 

--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ helm delete $(helm list | grep ffdl | awk '{print $1}' | head -n 1)
 
 * To remove FfDL on your Cluster, simply run `make undeploy`
 
+* Since the current implementation of FfDL will need write access for its mounted volume, if you are using Kubernetes 1.9.4 or above, please modify the feature gate `ReadOnlyAPIDataVolumes=false`. 
+
 ## 9. References
 
 Based on IBM Research work in Deep Learning.


### PR DESCRIPTION
Minikube updated its Kubernetes Version to 1.9.4 yesterday and it made the Travis failed.

Kubernetes 1.9.4 changes secret, configMap, downwardAPI and projected volumes to mount read-only which cause our current learner implementation to be failed. Adding the feature gate `ReadOnlyAPIDataVolumes=false` will temporary resolve this issue in CI. Since the community said is not a good practice to let a pod to modify mounted secret, configMap, downwardAPI and projected volumes, we should change our learner implementation during our next sync. 