### PR TITLE
Update learner entrypoint command to work on k8s 1.9.4 and above

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ install-minikube-in-ci:
 		chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 	@curl -s -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && \
 		chmod +x minikube && sudo mv minikube /usr/local/bin/
-	@sudo minikube start --vm-driver=none --feature-gates=ReadOnlyAPIDataVolumes=false
+	@sudo minikube start --vm-driver=none
 	@minikube update-context
 	@JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; \
 		until kubectl get nodes -o jsonpath="$$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ FfDL is a collaboration platform for:
 
 ## Usage Scenarios
 
-* If you already have a FfDL deployment up and running, you can jump to [FfDL User Guide](docs/user-guide.md) to use FfDL for training your models. 
+* If you already have a FfDL deployment up and running, you can jump to [FfDL User Guide](docs/user-guide.md) to use FfDL for training your models.
 
 * If you have FfDL confiugured to use GPUs, and want to train using GPUs, follow steps [here](docs/gpu-guide.md)
 
 * If you have used FfDL to train your models, and want to use a GPU enabled public cloud hosted service for further training and serving, please follow instructions [here](etc/converter/ffdl-wml.md) to train and serve your models using [Watson Studio Deep Learning](https://www.ibm.com/cloud/machine-learning) service
 
-* If you are starting and want to setup your own FfDL deployment, please follow the steps below. 
+* If you are starting and want to setup your own FfDL deployment, please follow the steps below.
 
 ## Steps
 
@@ -402,8 +402,6 @@ helm delete $(helm list | grep ffdl | awk '{print $1}' | head -n 1)
   make sure to follow the standard Go directory layout (see [Prerequisites section]{#Prerequisites}).
 
 * To remove FfDL on your Cluster, simply run `make undeploy`
-
-* Since the current implementation of FfDL needs write access for its mounted volume, if you are using Kubernetes 1.9.4 or above, please modify the feature gate `ReadOnlyAPIDataVolumes=false`. 
 
 ## 9. References
 

--- a/lcm/service/lcm/container_helper_extensions.go
+++ b/lcm/service/lcm/container_helper_extensions.go
@@ -35,7 +35,7 @@ func extendLearnerContainer(learner *v1core.Container, req *service.JobDeploymen
 		// TODO!
 	}
 
-	extCmd := "export PATH=" + learnerEntrypointFilesPath + ":$PATH; chmod +x " + learnerEntrypointFilesPath + "/*.sh; "
+	extCmd := "export PATH=/:$PATH; cp " + learnerEntrypointFilesPath + "/*.sh /; chmod +x /*.sh; "
 	extMount := v1core.VolumeMount{
 		Name:      learnerEntrypointFilesVolume,
 		MountPath: learnerEntrypointFilesPath,

--- a/lcm/service/lcm/container_helper_extensions.go
+++ b/lcm/service/lcm/container_helper_extensions.go
@@ -35,7 +35,7 @@ func extendLearnerContainer(learner *v1core.Container, req *service.JobDeploymen
 		// TODO!
 	}
 
-	extCmd := "export PATH=/:$PATH; cp " + learnerEntrypointFilesPath + "/*.sh /; chmod +x /*.sh; "
+	extCmd := "export PATH=/usr/local/bin/:$PATH; cp " + learnerEntrypointFilesPath + "/*.sh /usr/local/bin/; chmod +x /usr/local/bin/*.sh;"
 	extMount := v1core.VolumeMount{
 		Name:      learnerEntrypointFilesVolume,
 		MountPath: learnerEntrypointFilesPath,


### PR DESCRIPTION
Starting from Kubernetes 1.9.4, all the mounted Secrets and ConfigMaps are now read only. Therefore, we update the learner entrypoint commands to copy the entrypoint script and execute on Host path instead on the configMap path. This will fix #46.

@sboagibm Please review the entrypoint commands. If it looks good to you, I will update the DockerHub ffdl-lcm images and merge this PR.