### PR TITLE
Set localstack to a stable version

### DIFF
--- a/templates/infrastructure/storage.yml
+++ b/templates/infrastructure/storage.yml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: storage
-          image: localstack/localstack
+          image: localstack/localstack:0.8.6
 {{ if .Values.docker.pullPolicy }}
           imagePullPolicy: {{.Values.docker.pullPolicy}}
 {{ end }}


### PR DESCRIPTION
Some users experiencing CrashLoopBackOff for the `ffdl-trainingdata`. One of the main reason causing this is the latest localstack (updated a day ago) is incapable with our `ffdl-trainingdata`. Thus, pointing localstack to version 0.8.6 to make `ffdl-trainingdata` stable and avoid issues like #61 happens again. 

Signed-off-by: Tommy Li <tommy.chaoping.li@ibm.com>
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

