### PR TITLE
Make helper pods spec, namespaces, and other features configurable. 

### DIFF
--- a/commons/config/config.go
+++ b/commons/config/config.go
@@ -299,6 +299,8 @@ func GetPodName() string {
 func GetPodNamespace() string {
 	if viper.IsSet(PodNamespaceKey) {
 		return viper.GetString(PodNamespaceKey)
+	} else if os.Getenv("FFDL_NAMESPACE") != "" {
+		return os.Getenv("FFDL_NAMESPACE")
 	}
 	return "default"
 }
@@ -306,6 +308,8 @@ func GetPodNamespaceForPrometheus() string {
 	namespace := "default"
 	if viper.IsSet(PodNamespaceKey) {
 		namespace = viper.GetString(PodNamespaceKey)
+	} else if os.Getenv("FFDL_NAMESPACE") != "" {
+		namespace = os.Getenv("FFDL_NAMESPACE")
 	}
 	namespace = strings.Replace(namespace, "-", "", -1)
 	return namespace
@@ -315,6 +319,8 @@ func GetPodNamespaceForPrometheus() string {
 func GetLearnerNamespace() string {
 	if viper.IsSet(LearnerKubeNamespaceKey) {
 		return viper.GetString(LearnerKubeNamespaceKey)
+	} else if os.Getenv("FFDL_NAMESPACE") != "" {
+		return os.Getenv("FFDL_NAMESPACE")
 	}
 	return "default"
 }

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -69,4 +69,4 @@ You need to modify the following sections to deploy FfDL in a non default namesp
  ```shell
  kubectl config set-context $(kubectl config current-context) --namespace=<namespace>
  ```
-4. If you are using the local S3 for storing your dataset, make sure you changed the KubeDNS auth_url to targets the new namespace. (e.g.  `http://s3.<namespace>.svc.cluster.local`)
+4. If you are using the local S3 for storing your dataset, make sure you changed the KubeDNS auth_url in your training job's manifest file to targets the new namespace. (e.g.  `http://s3.<namespace>.svc.cluster.local`)

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -34,19 +34,13 @@ environment (using `helm`):
 make deploy
 ```
 
-## Enable device plugin for GPU workloads with development build
+## Enable accelerator for GPU workloads with development build
 
-Please modify the `resourceGPU` under [lcm/service/lcm/container_helper.go](../lcm/service/lcm/container_helper.go#L530) and [lcm/service/lcm/resources.go](../lcm/service/lcm/resources.go#L149) to `"nvidia.com/gpu"` and rebuild the lcm image to enable device plugin for all GPU workloads on your development build.
+To enable accelerator for all GPU workloads on your development build, change [values.yaml](../values.yaml#L30)'s `lcm.GPU_resources` to **accelerator** and redeploy FfDL.
 
 ## Enable custom learner images with development build
 
-Please uncomment the following section under [trainer/trainer/frameworks.go](../trainer/trainer/frameworks.go#L39) and rebuild the trainer image to enable custom learner images from any users. Alternatively, you can use the pre-built images `ffdl/ffdl-trainer:customizable` on DockerHub.
-
-``` go
-if fwName == "custom" {
-  return true, ""
-}
-```
+To enable custom learner images from any users, change [values.yaml](../values.yaml#L17)'s `trainer.customizable` to **true** and redeploy FfDL.
 
 After you deployed `ffdl-trainer` with custom image feature, you can use your custom learner images by changing the `framework.name` to **custom** and `framework.version` to your learner image in your training job's manifest.yml file. If you are using any private registry, you need to enable access to the private registry in your Kubernetes default namespace.
 
@@ -70,7 +64,7 @@ If your Kubernetes Cluster has a lot of resources and you want to enhance the tr
 
 You need to modify the following sections to deploy FfDL in a non default namespace.
 1. Change [values.yaml](../values.yaml#L1)'s `namespace` section. (Note that the helm chart will create the namespace for you)
-2. Change [values.yaml](../values.yaml#L69)'s `objectstore.auth_url` section with the new KubeDNS link that targets the new namespace. (e.g.  `http://s3.<namespace>.svc.cluster.local`)
+2. Change [values.yaml](../values.yaml#L71)'s `objectstore.auth_url` section with the new KubeDNS link that targets the new namespace. (e.g.  `http://s3.<namespace>.svc.cluster.local`)
 3. Since all the scripts and command are targeting the default namespace, you need to change the namespace preference after you run helm install.
  ```shell
  kubectl config set-context $(kubectl config current-context) --namespace=<namespace>

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -16,6 +16,7 @@ Install:
 * `Go` is very specific about directory layouts. Make sure to set your `$GOPATH` and clone this repo to a directory
 `$GOPATH/src/github.com/IBM/FfDL` before proceeding with the next steps.
 
+> For Minikube, run `eval $(minikube docker-env)` to point your Docker CLI to the Minikube's Docker daemon.
 
 Then, fetch the dependencies via:
 ```
@@ -48,3 +49,30 @@ if fwName == "custom" {
 ```
 
 After you deployed `ffdl-trainer` with custom image feature, you can use your custom learner images by changing the `framework.name` to **custom** and `framework.version` to your learner image in your training job's manifest.yml file. If you are using any private registry, you need to enable access to the private registry in your Kubernetes default namespace.
+
+## Customize helper pod specs
+
+If your Kubernetes Cluster has a lot of resources and you want to enhance the training jobs execution speed, you can modify the helper pod spec under [values.yaml](../values.yaml).
+
+* `storeResultsMilliCPU`: Store Results is responsible for storing all the training result. Increasing this number along with `storeResultsMemInMB` can accelerate the storing stage of the training job. Default = 20.
+* `storeResultsMemInMB`: See above. Default = 100
+* `loadModelMilliCPU` : Load Model is responsible for loading any model data you submitted to the learner container. Increasing this number along with `loadModelMemInMB` can accelerate the download stage of the training job. Default = 20.
+* `loadModelMemInMB`: See above. Default = 50.
+* `loadTrainingDataMilliCPU`: Load Training Data is responsible for loading any training data in the object storage to the learner container. Increasing this number along with `loadTrainingDataMemInMB` can accelerate the download stage of the training job. Default = 20.
+* `loadTrainingDataMemInMB`: See above. Default = 300.
+* `logCollectorMilliCPU`: Log Collector is responsible for collecting any log and metadata from the learner containers. Increasing this number along with `logCollectorMemInMB` can allow Log Collector to collect more logs and TF summary data. Default = 60.
+* `logCollectorMemInMB`: See above. Default = 300.
+* `controllerMilliCPU`: Controller is responsible for giving instructions (e.g. halting jobs) to the learners. Increasing this number along with `controllerMemInMB` can let the training job to be more responsive for your changes. Default = 20.
+* `controllerMemInMB`: See above. Default = 100.
+
+
+## Deploy FfDL in a dedicated namespace
+
+You need to modify the following sections to deploy FfDL in a non default namespace.
+1. Change [values.yaml](../values.yaml#L1)'s `namespace` section. (Note that the helm chart will create the namespace for you)
+2. Change [values.yaml](../values.yaml#L69)'s `objectstore.auth_url` section with the new KubeDNS link that targets the new namespace. (e.g.  `http://s3.<namespace>.svc.cluster.local`)
+3. Since all the scripts and command are targeting the default namespace, you need to change the namespace preference after you run helm install.
+ ```shell
+ kubectl config set-context $(kubectl config current-context) --namespace=<namespace>
+ ```
+4. If you are using the local S3 for storing your dataset, make sure you changed the KubeDNS auth_url to targets the new namespace. (e.g.  `http://s3.<namespace>.svc.cluster.local`)

--- a/docs/gpu-guide.md
+++ b/docs/gpu-guide.md
@@ -4,8 +4,8 @@
 
 ### Prerequisites
 
-* You need to have a Kubernetes cluster configured to use GPUs. Currently tested with Kubernetes configured using [feature gate `Accelerators`](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/). If you are using device plugin, please modify the
-[values.yaml](../values.yaml)'s lcm.version to `device-plugin` and redeploy FfDL.
+* You need to have a Kubernetes cluster configured to use GPUs. Currently tested with Kubernetes configured using [feature gate `DevicePlugins`](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/). If you are using Accelerators, please modify the
+[values.yaml](../values.yaml#L30)'s `lcm.GPU_resources` to **accelerator** and redeploy FfDL.
 
 * You need to have [FfDL](../README.md#5-detailed-installation-instructions) running on your Cluster.
 
@@ -16,7 +16,7 @@
 ### TensorFlow example
 
 To run the TensorFlow job with GPU, simply go to the [tf-model's manifest file](../etc/examples/tf-model/manifest.yml) and do the following changes
-* Change the framework version from `latest` to `latest-gpu` for CUDA 9 Driver or `1.3.0-gpu` for CUDA 8 Driver.
+* Change the framework version from `1.5.0-py3` to `1.5.0-gpu-py3` for CUDA 9 Driver or `1.4.0-gpu-py3` for CUDA 8 Driver.
 * Change the `gpus` section to be greater than 0, so the learner can get GPU resource to train the job.
 
 The `etc/examples/tf-model/gpu-manifest.yml` is the example manifest file for running the TensorFlow example with GPU. Once you have done the above changes, you can following the same [testing instructions](../README.md#6-detailed-testing-instructions) on the main README to run the sample TensorFlow job on GPU.

--- a/lcm/service/lcm/constants.go
+++ b/lcm/service/lcm/constants.go
@@ -70,21 +70,6 @@ const (
 )
 
 const (
-	//Total CPU for helpers = 2.5
-	//Total RAM for helpers = 4 GB
-	storeResultsMilliCPU=20
-	storeResultsMemInMB=100
-	loadModelMilliCPU=20
-	loadModelMemInMB=50
-	loadTrainingDataMilliCPU=20
-	loadTrainingDataMemInMB=300
-	logCollectorMilliCPU=60
-	logCollectorMemInMB=300
-	controllerMilliCPU=20
-	controllerMemInMB=100
-)
-
-const (
 	reason                          = "reason"
 	framework                       = "framework"
 	progress                        = "progress"

--- a/lcm/service/lcm/container_helper.go
+++ b/lcm/service/lcm/container_helper.go
@@ -550,8 +550,10 @@ func constructLearnerContainer(req *service.JobDeploymentRequest, learnerID int,
 	}
 	cmd := wrapCommand(command, learnerContainerName, PodLevelJobDir)
 
-	// Set the resourceGPU to "nvidia.com/gpu" if you want to run your GPU workloads using device plugin.
-	var resourceGPU v1core.ResourceName = v1core.ResourceNvidiaGPU
+	var resourceGPU v1core.ResourceName = "nvidia.com/gpu"
+	if os.Getenv("GPU_resources") == "accelerator" {
+		resourceGPU = v1core.ResourceNvidiaGPU
+	}
 
 	learnerContainer := v1core.Container{
 		Name:            learnerContainerName,

--- a/lcm/service/lcm/container_helper.go
+++ b/lcm/service/lcm/container_helper.go
@@ -121,10 +121,10 @@ var (
 func getHelperSpec(specName string) int {
 	result, err := strconv.Atoi(os.Getenv(specName))
 	if err != nil {
-			return 100 // Default spec for helper pod
-    }
-	return result
+		return 100 // Default spec for helper pod
 	}
+	return result
+}
 
 func constructControllerContainer(learnerNodeBasePath, learnerNodeStatusPath, summaryMetricsPath, jobBasePath string, jobVolumeMount v1core.VolumeMount, etcdVolumeName string, logr *logger.LocLoggingEntry, mountTrainingDataStoreInLearner, mountResultsStoreInLearner bool) v1core.Container {
 

--- a/lcm/service/lcm/container_helper.go
+++ b/lcm/service/lcm/container_helper.go
@@ -21,6 +21,8 @@ import (
 	"path"
 	"strings"
 	"text/template"
+	"os"
+	"strconv"
 
 	"github.com/IBM/FfDL/commons/config"
 	"github.com/IBM/FfDL/commons/service"
@@ -101,6 +103,28 @@ const PodLevelJobDir = "/job"
 
 // PodLevelLogDir represents the place to store the per-learner logs.
 const PodLevelLogDir = PodLevelJobDir + "/logs"
+
+// Helper pods spec
+var (
+	storeResultsMilliCPU = getHelperSpec("storeResultsMilliCPU")
+	storeResultsMemInMB = getHelperSpec("storeResultsMemInMB")
+	loadModelMilliCPU = getHelperSpec("loadModelMilliCPU")
+	loadModelMemInMB = getHelperSpec("loadModelMemInMB")
+	loadTrainingDataMilliCPU = getHelperSpec("loadTrainingDataMilliCPU")
+	loadTrainingDataMemInMB = getHelperSpec("loadTrainingDataMemInMB")
+	logCollectorMilliCPU = getHelperSpec("logCollectorMilliCPU")
+	logCollectorMemInMB = getHelperSpec("logCollectorMemInMB")
+	controllerMilliCPU = getHelperSpec("controllerMilliCPU")
+	controllerMemInMB = getHelperSpec("controllerMemInMB")
+)
+
+func getHelperSpec(specName string) int {
+	result, err := strconv.Atoi(os.Getenv(specName))
+	if err != nil {
+			return 100 // Default spec for helper pod
+    }
+	return result
+	}
 
 func constructControllerContainer(learnerNodeBasePath, learnerNodeStatusPath, summaryMetricsPath, jobBasePath string, jobVolumeMount v1core.VolumeMount, etcdVolumeName string, logr *logger.LocLoggingEntry, mountTrainingDataStoreInLearner, mountResultsStoreInLearner bool) v1core.Container {
 

--- a/lcm/service/lcm/job_monitor_deployment_helpers.go
+++ b/lcm/service/lcm/job_monitor_deployment_helpers.go
@@ -139,6 +139,7 @@ func defineJobMonitorDeployment(req *service.JobDeploymentRequest, envVars []v1c
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: jmName,
+			Namespace: config.GetPodNamespace(),
 		},
 		Spec: v1beta1.DeploymentSpec{
 			Strategy: v1beta1.DeploymentStrategy{
@@ -161,6 +162,7 @@ func defineJobMonitorDeployment(req *service.JobDeploymentRequest, envVars []v1c
 						"app":         jmName,
 						"training_id": req.TrainingId,
 					},
+					Namespace: config.GetPodNamespace(),
 				},
 				Spec: v1core.PodSpec{
 					Volumes: []v1core.Volume{

--- a/lcm/service/lcm/learner_deployment_helpers.go
+++ b/lcm/service/lcm/learner_deployment_helpers.go
@@ -57,6 +57,7 @@ func defineLearnerService(name string, trainingID string) *v1core.Service {
 			Labels: map[string]string{
 				"training_id": trainingID,
 			},
+			Namespace: config.GetPodNamespace(),
 		},
 		Spec: v1core.ServiceSpec{
 			Type:     v1core.ServiceTypeClusterIP,
@@ -489,6 +490,7 @@ func getGpuDeploymentSpec(name string, trainingID string, schedulePolicy string,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			Namespace: config.GetPodNamespace(),
 		},
 		Spec: v1beta1.DeploymentSpec{
 			Strategy: v1beta1.DeploymentStrategy{

--- a/lcm/service/lcm/ps_deployment_helpers.go
+++ b/lcm/service/lcm/ps_deployment_helpers.go
@@ -129,6 +129,7 @@ func definePSDeployment(req *service.JobDeploymentRequest, envVars []v1core.EnvV
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: psName,
+			Namespace: config.GetPodNamespace(),
 		},
 		Spec: v1beta1.DeploymentSpec{
 			Strategy: v1beta1.DeploymentStrategy{
@@ -152,6 +153,7 @@ func definePSDeployment(req *service.JobDeploymentRequest, envVars []v1core.EnvV
 						"training_id": req.TrainingId,
 						"service":     "dlaas-parameter-server",
 					},
+					Namespace: config.GetPodNamespace(),
 				},
 				Spec: v1core.PodSpec{
 					Containers: []v1core.Container{
@@ -227,6 +229,7 @@ func definePSService(psName string, trainingID string) *v1core.Service {
 				"training_id": trainingID,
 				"service":     "dlaas-parameter-server",
 			},
+			Namespace: config.GetPodNamespace(),
 		},
 		Spec: v1core.ServiceSpec{
 			Type:     v1core.ServiceTypeClusterIP,

--- a/lcm/service/lcm/resources.go
+++ b/lcm/service/lcm/resources.go
@@ -20,6 +20,7 @@ import (
 	//"errors"
 	"strconv"
 	"time"
+	"os"
 
 	v1core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -145,8 +146,10 @@ func getResources(s *lcmService, logr *logger.LocLoggingEntry) (bool, *allocatab
 		}
 	}
 
-	// Set the resourceGPU to "nvidia.com/gpu" if you want to run your GPU workloads using device plugin.
-	var resourceGPU v1core.ResourceName = v1core.ResourceNvidiaGPU
+	var resourceGPU v1core.ResourceName = "nvidia.com/gpu"
+	if os.Getenv("GPU_resources") == "accelerator" {
+		resourceGPU = v1core.ResourceNvidiaGPU
+	}
 
 	//By querying nodes, determine the number of allocatable resources
 	for _, node := range nodes.Items {

--- a/templates/infrastructure/etcd.yml
+++ b/templates/infrastructure/etcd.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: etcd
+  namespace: {{.Values.namespace}}
 spec:
   ports:
   - port: 2379
@@ -19,6 +20,7 @@ metadata:
     app: etcd
     etcd_node: etcd0
   name: etcd0
+  namespace: {{.Values.namespace}}
 spec:
   containers:
   - command:
@@ -57,6 +59,7 @@ metadata:
   labels:
     etcd_node: etcd0
   name: etcd0
+  namespace: {{.Values.namespace}}
 spec:
   ports:
   - name: client

--- a/templates/infrastructure/mongo.yml
+++ b/templates/infrastructure/mongo.yml
@@ -2,6 +2,7 @@ apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: mongo
+  namespace: {{.Values.namespace}}
 spec:
   serviceName: mongo
   replicas: 1
@@ -36,6 +37,7 @@ metadata:
   name: mongo
   labels:
     environment: local
+  namespace: {{.Values.namespace}}
 spec:
   ports:
   - port: 27017

--- a/templates/infrastructure/storage.yml
+++ b/templates/infrastructure/storage.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: s3
+  namespace: {{.Values.namespace}}
 spec:
 {{ if .Values.services.expose_node_port }}
   type: NodePort
@@ -21,6 +22,7 @@ metadata:
   name: elasticsearch
   labels:
     component: elasticsearch
+  namespace: {{.Values.namespace}}
 spec:
 {{ if .Values.services.expose_node_port }}
   type: NodePort
@@ -39,6 +41,7 @@ apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: storage
+  namespace: {{.Values.namespace}}
 spec:
   serviceName: storage
   replicas: 1
@@ -49,7 +52,7 @@ spec:
     spec:
       containers:
         - name: storage
-          image: localstack/localstack
+          image: localstack/localstack:0.8.6
 {{ if .Values.docker.pullPolicy }}
           imagePullPolicy: {{.Values.docker.pullPolicy}}
 {{ end }}

--- a/templates/monitoring/alertmanager-configmap.yml
+++ b/templates/monitoring/alertmanager-configmap.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-alertmanager
+  namespace: {{.Values.namespace}}
 data:
   alertmanager.yml: |-
     global:

--- a/templates/monitoring/alertmanager-deployment.yml
+++ b/templates/monitoring/alertmanager-deployment.yml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: alertmanager
+  namespace: {{.Values.namespace}}
 spec:
   replicas: 1
   selector:

--- a/templates/monitoring/alertmanager-service.yml
+++ b/templates/monitoring/alertmanager-service.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     name: alertmanager
   name: alertmanager
+  namespace: {{.Values.namespace}}
 spec:
   selector:
     app: alertmanager

--- a/templates/monitoring/alertrules-configmap.yml
+++ b/templates/monitoring/alertrules-configmap.yml
@@ -1,79 +1,80 @@
-apiVersion: v1  
-kind: ConfigMap  
-metadata:  
-  name: prometheus-alertrules  
-data:  
-  alert.rules: |-  
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-alertrules
+  namespace: {{.Values.namespace}}
+data:
+  alert.rules: |-
 
-    ALERT ControllerJobFailures  
+    ALERT ControllerJobFailures
       IF increase(controller_training_failures[2m])  >= 1
-      LABELS { criticality = "S2" }  
-      ANNOTATIONS {  
-        summary = "Controller indicates failing learnings",  
-        description = "Controller seems to have a rate > 1 of failed learnings over last 2 mins",  
-      }  
-    
-    ALERT ControllerETCDFailures  
-      IF increase(controller_etcd_failures{attempt="4"}[2m])  >= 1
-      LABELS { criticality = "S2" }  
-      ANNOTATIONS {  
-        summary = "Controller indicates failure to connect to etcd",  
-        description = "Controller seems to have a rate > 1 in connecting to etcd over last 2 mins after 5 attempts",  
-      } 
-    
-    ALERT SwiftObjectStoreFailures  
-      IF increase(databroker_upload_failures{store="swift", attempt="4"}[2m]) > 1
-      LABELS { criticality = "S2" }  
-      ANNOTATIONS {  
-        summary = "Swift upload/download failures",  
-        description = "Databroker has had more than 1 failures after 5 attempts while uploading/downloading data",  
-      }  
-
-    ALERT S3ObjectStoreFailures  
-      IF increase(databroker_upload_failures{store="s3", attempt="4"}[2m]) > 1
-      LABELS { criticality = "S2" }  
-      ANNOTATIONS {  
-        summary = "S3 upload/download failures",  
-        description = "Databroker has had more than 1 failures after 5 attempts while uploading/downloading data",  
+      LABELS { criticality = "S2" }
+      ANNOTATIONS {
+        summary = "Controller indicates failing learnings",
+        description = "Controller seems to have a rate > 1 of failed learnings over last 2 mins",
       }
 
-    ALERT LCMRestarts  
+    ALERT ControllerETCDFailures
+      IF increase(controller_etcd_failures{attempt="4"}[2m])  >= 1
+      LABELS { criticality = "S2" }
+      ANNOTATIONS {
+        summary = "Controller indicates failure to connect to etcd",
+        description = "Controller seems to have a rate > 1 in connecting to etcd over last 2 mins after 5 attempts",
+      }
+
+    ALERT SwiftObjectStoreFailures
+      IF increase(databroker_upload_failures{store="swift", attempt="4"}[2m]) > 1
+      LABELS { criticality = "S2" }
+      ANNOTATIONS {
+        summary = "Swift upload/download failures",
+        description = "Databroker has had more than 1 failures after 5 attempts while uploading/downloading data",
+      }
+
+    ALERT S3ObjectStoreFailures
+      IF increase(databroker_upload_failures{store="s3", attempt="4"}[2m]) > 1
+      LABELS { criticality = "S2" }
+      ANNOTATIONS {
+        summary = "S3 upload/download failures",
+        description = "Databroker has had more than 1 failures after 5 attempts while uploading/downloading data",
+      }
+
+    ALERT LCMRestarts
       IF increase(lcm_restart_total[2m]) > 1
-      LABELS { criticality = "S2" }  
-      ANNOTATIONS {  
-        summary = "LCM restarts because of failures",  
-        description = "LCM has restarted more than 1 in last 2mins because of failures",  
+      LABELS { criticality = "S2" }
+      ANNOTATIONS {
+        summary = "LCM restarts because of failures",
+        description = "LCM has restarted more than 1 in last 2mins because of failures",
       }
 
 
     ALERT LCMTrainingsFailure
       IF sum(increase(lcm_trainings_launch_failed[2m])) by (reason, instance, job) > 1
-      LABELS { criticality = "S2" }  
-      ANNOTATIONS {  
+      LABELS { criticality = "S2" }
+      ANNOTATIONS {
         summary = "LCM failed to launch trainging because of {{`{{$labels.reason}}`}}",
         description = "LCM failed to launch more than 1 trainings for last 2 mins because of {{`{{$labels.reason}}`}}",
       }
 
     ALERT JobMonitorConnectivityFailure
         IF sum(increase(jobmonitor_connectivity_failures[2m])) by (reason, instance, job) > 1
-        LABELS { criticality = "S2" }  
-        ANNOTATIONS {  
+        LABELS { criticality = "S2" }
+        ANNOTATIONS {
           summary = "JobMonitor failed to launch training because of {{`{{$labels.reason}}`}}",
           description = "JobMonitor failed to launch more than 1 trainings for last 2 mins because of {{`{{$labels.reason}}`}}",
-        } 
+        }
 
     ALERT JobMonitorK8sAPIFailure
         IF sum(increase(jobmonitor_k8s_failures[2m])) by (reason, instance, job) > 1
-        LABELS { criticality = "S2" }  
-        ANNOTATIONS {  
+        LABELS { criticality = "S2" }
+        ANNOTATIONS {
           summary = "JobMonitor failed to launch training because of {{`{{$labels.reason}}`}}",
           description = "JobMonitor failed to launch more than 1 trainings for last 2 mins because of {{`{{$labels.reason}}`}}",
-        } 
+        }
 
     ALERT TrainerRatelimitingInvoked
         IF increase(trainer_ratelimitinvocations_total[2m]) > 5
-        LABELS { criticality = "S2" }  
-        ANNOTATIONS {  
-          summary = "Invoked rate limiting on trainer for more than 5 times in a 2 minute window",  
-          description = "Trainer is running into rate limiting issues",  
+        LABELS { criticality = "S2" }
+        ANNOTATIONS {
+          summary = "Invoked rate limiting on trainer for more than 5 times in a 2 minute window",
+          description = "Trainer is running into rate limiting issues",
         }

--- a/templates/monitoring/prometheus-configmap.yml
+++ b/templates/monitoring/prometheus-configmap.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus
+  namespace: {{.Values.namespace}}
 data:
   prometheus.yml: |-
     global:

--- a/templates/monitoring/prometheus-deployment.yml
+++ b/templates/monitoring/prometheus-deployment.yml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: prometheus
+  namespace: {{.Values.namespace}}
 spec:
   replicas: 1
   selector:

--- a/templates/monitoring/prometheus-service.yml
+++ b/templates/monitoring/prometheus-service.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     name: prometheus
   name: prometheus
+  namespace: {{.Values.namespace}}
 spec:
   selector:
     app: prometheus
@@ -22,6 +23,7 @@ metadata:
   labels:
     name: grafana
   name: grafana
+  namespace: {{.Values.namespace}}
 spec:
   selector:
     app: prometheus

--- a/templates/monitoring/pushgateway-configmap.yml
+++ b/templates/monitoring/pushgateway-configmap.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: statsd-exporter-configmap
+  namespace: {{.Values.namespace}}
 data:
   mapping.conf: |-
     mappings:
@@ -34,7 +35,7 @@ data:
       labels:
         reason: "$1"
         job: "jobmonitor"
-    
+
     - match: jobmonitor.jobmonitor.k8s.*.failed
       help: "Total number of k8s related failures in jobmonitor"
       name: "jobmonitor_k8s_failures"

--- a/templates/monitoring/pushgateway-deployment.yml
+++ b/templates/monitoring/pushgateway-deployment.yml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: pushgateway
+  namespace: {{.Values.namespace}}
 spec:
   replicas: 1
   selector:

--- a/templates/monitoring/pushgateway-service.yml
+++ b/templates/monitoring/pushgateway-service.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     name: pushgateway
   name: pushgateway
+  namespace: {{.Values.namespace}}
 spec:
   selector:
     app: pushgateway

--- a/templates/services/lcm-deployment.yml
+++ b/templates/services/lcm-deployment.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     service: ffdl-lcm
     environment: {{.Values.env}}
+  namespace: {{.Values.namespace}}
 spec:
   selector:
     matchLabels:
@@ -79,6 +80,28 @@ spec:
           value: {{.Values.learner.tag}}
         - name: DLAAS_LEARNER_REGISTRY
           value: {{.Values.docker.registry}}/{{.Values.learner.docker_namespace}}
+        - name: storeResultsMilliCPU
+          value: "{{.Values.helper.storeResultsMilliCPU}}"
+        - name: storeResultsMemInMB
+          value: "{{.Values.helper.storeResultsMemInMB}}"
+        - name: loadModelMilliCPU
+          value: "{{.Values.helper.loadModelMilliCPU}}"
+        - name: loadModelMemInMB
+          value: "{{.Values.helper.loadModelMemInMB}}"
+        - name: loadTrainingDataMilliCPU
+          value: "{{.Values.helper.loadTrainingDataMilliCPU}}"
+        - name: loadTrainingDataMemInMB
+          value: "{{.Values.helper.loadTrainingDataMemInMB}}"
+        - name: logCollectorMilliCPU
+          value: "{{.Values.helper.logCollectorMilliCPU}}"
+        - name: logCollectorMemInMB
+          value: "{{.Values.helper.logCollectorMemInMB}}"
+        - name: controllerMilliCPU
+          value: "{{.Values.helper.controllerMilliCPU}}"
+        - name: controllerMemInMB
+          value: "{{.Values.helper.controllerMemInMB}}"
+        - name: FFDL_NAMESPACE
+          value: {{.Values.namespace}}
         - name: DLAAS_ETCD_ADDRESS
           valueFrom:
             secretKeyRef:

--- a/templates/services/lcm-deployment.yml
+++ b/templates/services/lcm-deployment.yml
@@ -100,6 +100,8 @@ spec:
           value: "{{.Values.helper.controllerMilliCPU}}"
         - name: controllerMemInMB
           value: "{{.Values.helper.controllerMemInMB}}"
+        - name: GPU_resources
+          value: {{.Values.lcm.GPU_resources}}
         - name: FFDL_NAMESPACE
           value: {{.Values.namespace}}
         - name: DLAAS_ETCD_ADDRESS

--- a/templates/services/lcm-secrets.yml
+++ b/templates/services/lcm-secrets.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: lcm-secrets
+  namespace: {{.Values.namespace}}
 type: Opaque
 data:
   DLAAS_ETCD_ADDRESS: {{.Values.etcd.address|b64enc}}

--- a/templates/services/lcm-service.yml
+++ b/templates/services/lcm-service.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     service: ffdl-lcm
     environment: {{.Values.env}}
+  namespace: {{.Values.namespace}}
 spec:
   ports:
   - name: grpc

--- a/templates/services/learner-configmap.yml
+++ b/templates/services/learner-configmap.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: learner-config
+  namespace: {{.Values.namespace}}
 data:
   tensorflow_cpu_latest_CURRENT: manual
   tensorflow_cpu_latest-py3_CURRENT: manual
@@ -38,6 +39,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: learner-entrypoint-files
+  namespace: {{.Values.namespace}}
 data:
   train.sh: |
     #!/bin/bash

--- a/templates/services/namespace.yml
+++ b/templates/services/namespace.yml
@@ -1,0 +1,6 @@
+{{ if ne .Values.namespace "default" }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{.Values.namespace}}
+{{end}}

--- a/templates/services/restapi-deployment.yml
+++ b/templates/services/restapi-deployment.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     service: ffdl-restapi
     environment: {{.Values.env}}
+  namespace: {{.Values.namespace}}
 spec:
   selector:
     matchLabels:
@@ -35,6 +36,8 @@ spec:
           value: {{.Values.env}}
         - name: DLAAS_LOGLEVEL
           value: {{.Values.log.level}}
+        - name: FFDL_NAMESPACE
+          value: {{.Values.namespace}}
 {{ if ne .Values.env "dev" }}
         - name: EUREKA_APP
           value: {{.Values.eureka.name}}

--- a/templates/services/restapi-service.yml
+++ b/templates/services/restapi-service.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     service: ffdl-restapi
     environment: {{.Values.env}}
+  namespace: {{.Values.namespace}}
 spec:
   type: NodePort
   ports:

--- a/templates/services/trainer-deployment.yml
+++ b/templates/services/trainer-deployment.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     environment: {{.Values.env}}
     service: ffdl-trainer
+  namespace: {{.Values.namespace}}
 spec:
   selector:
     matchLabels:
@@ -50,6 +51,8 @@ spec:
           value: {{.Values.log.level}}
         - name: DLAAS_PUSH_METRICS_ENABLED
           value: "true"
+        - name: FFDL_NAMESPACE
+          value: {{.Values.namespace}}
 {{ if eq .Values.env "dev" }}
         - name: DLAAS_MONGO_ADDRESS
           value: mongo.$(DLAAS_POD_NAMESPACE).svc.cluster.local

--- a/templates/services/trainer-deployment.yml
+++ b/templates/services/trainer-deployment.yml
@@ -51,6 +51,8 @@ spec:
           value: {{.Values.log.level}}
         - name: DLAAS_PUSH_METRICS_ENABLED
           value: "true"
+        - name: customizable
+          value: "{{.Values.trainer.customizable}}"
         - name: FFDL_NAMESPACE
           value: {{.Values.namespace}}
 {{ if eq .Values.env "dev" }}

--- a/templates/services/trainer-secrets.yml
+++ b/templates/services/trainer-secrets.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: trainer-secrets
+  namespace: {{.Values.namespace}}
 type: Opaque
 data:
 {{ if ne .Values.env "dev" }}

--- a/templates/services/trainer-service.yml
+++ b/templates/services/trainer-service.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     service: ffdl-trainer
     environment: {{.Values.env}}
+  namespace: {{.Values.namespace}}
 spec:
 {{ if .Values.services.expose_node_port }}
   type: NodePort

--- a/templates/services/trainingdata-deployment.yml
+++ b/templates/services/trainingdata-deployment.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     environment: {{.Values.env}}
     service: ffdl-trainingdata
+  namespace: {{.Values.namespace}}
 spec:
   selector:
     matchLabels:
@@ -46,6 +47,8 @@ spec:
           value: {{.Values.log.level}}
         - name: DLAAS_ELASTICSEARCH_SCHEME
           value: {{.Values.elasticsearch.scheme}}
+        - name: FFDL_NAMESPACE
+          value: {{.Values.namespace}}
 {{ if eq .Values.env "dev" }}
         - name: DLAAS_ELASTICSEARCH_ADDRESS
           value: {{.Values.elasticsearch.address}}

--- a/templates/services/trainingdata-secrets.yml
+++ b/templates/services/trainingdata-secrets.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: trainingdata-secrets
+  namespace: {{.Values.namespace}}
 type: Opaque
 data:
   DLAAS_ELASTICSEARCH_ADDRESS: {{.Values.elasticsearch.address|b64enc}}

--- a/templates/services/trainingdata-service.yml
+++ b/templates/services/trainingdata-service.yml
@@ -4,6 +4,7 @@ metadata:
   name: ffdl-trainingdata
   labels:
     environment: {{.Values.env}}
+  namespace: {{.Values.namespace}}
 spec:
 {{ if .Values.services.expose_node_port }}
   type: NodePort

--- a/templates/services/web-ui.yml
+++ b/templates/services/web-ui.yml
@@ -4,6 +4,7 @@ metadata:
   name: ffdl-ui
   labels:
     service: ffdl-ui
+  namespace: {{.Values.namespace}}
 spec:
   selector:
     matchLabels:
@@ -37,6 +38,7 @@ metadata:
   labels:
     service: ffdl-ui
     environment: {{.Values.env}}
+  namespace: {{.Values.namespace}}
 spec:
 {{ if .Values.services.expose_node_port }}
   type: NodePort

--- a/trainer/trainer/frameworks.go
+++ b/trainer/trainer/frameworks.go
@@ -21,6 +21,7 @@ import (
 	"github.com/IBM/FfDL/trainer/trainer/grpc_trainer_v2"
 	"strings"
 	"github.com/IBM/FfDL/commons/config"
+	"os"
 )
 
 func validateFrameworks(fw *grpc_trainer_v2.Framework) (bool, string) {
@@ -35,10 +36,11 @@ func validateFrameworks(fw *grpc_trainer_v2.Framework) (bool, string) {
 		return false, "framework version is required"
 	}
 
-	// Uncomment the below condition to enable users to apply any custom learner.
-	// if fwName == "custom" {
-	// 	return true, ""
-	// }
+	if strings.ToLower(os.Getenv("customizable")) == "true" {
+		if fwName == "custom" {
+			return true, ""
+		}
+	}
 
 	loc := config.GetCurrentLearnerConfigLocation(fwName, fwVersion)
 	if loc == "" {

--- a/values.yaml
+++ b/values.yaml
@@ -36,6 +36,17 @@ learner:
   tag: master-97
   docker_namespace: ffdl
   kubeSecret: lcm-secrets
+helper:
+  storeResultsMilliCPU: 20
+  storeResultsMemInMB: 100
+  loadModelMilliCPU: 20
+  loadModelMemInMB: 50
+  loadTrainingDataMilliCPU: 20
+  loadTrainingDataMemInMB: 300
+  logCollectorMilliCPU: 60
+  logCollectorMemInMB: 300
+  controllerMilliCPU: 20
+  controllerMemInMB: 100
 databroker:
   tag: latest
 webui:

--- a/values.yaml
+++ b/values.yaml
@@ -14,6 +14,7 @@ trainer:
   replicas: 1
   cpus: 100m
   memory: 64Mi
+  customizable: false
 restapi:
   version: latest
   port: 0
@@ -26,6 +27,7 @@ lcm:
   replicas: 1
   cpus: 100m
   memory: 64Mi
+  GPU_resources: device-plugin
 trainingdata:
   version: latest
   port: 0


### PR DESCRIPTION
This PR allows users to configure their helper pods specs and namespaces using the helm values.yml. The default namespace remains as `default`, but this will help us migrate to a dedicated namespaces in the future. 

This PR also allows users to pick how to consume GPU resources via the values.yml, so they don't have to pull or build a different docker image for different environments.

All the major documentations are available at the [developer-guide.md](https://github.com/IBM/FfDL/blob/variable-patch/docs/developer-guide.md). This gives more options and flexibility for developers to try FfDL on different environments with different capability. 

This closes #54, closes #55, and closes #56.

Signed-off-by: Tommy Li <tommy.chaoping.li@ibm.com>

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

