### PR TITLE
Add missing Python imports

### DIFF
--- a/etc/examples/caffe2-model/mnist.py
+++ b/etc/examples/caffe2-model/mnist.py
@@ -26,7 +26,7 @@ import time
 import os
 
 from caffe2.python import core, workspace, experiment_util, data_parallel_model
-from caffe2.python import dyndep, optimizer
+from caffe2.python import data_parallel_model_utils, dyndep, optimizer
 from caffe2.python import timeout_guard, model_helper, brew
 from caffe2.proto import caffe2_pb2
 

--- a/etc/examples/tf-model/input_data.py
+++ b/etc/examples/tf-model/input_data.py
@@ -4,6 +4,7 @@
 """Functions for downloading and reading MNIST data."""
 import gzip
 import os
+from six.moves import xrange
 from six.moves.urllib.request import urlretrieve
 import numpy
 

--- a/etc/examples/tf-summary-model/input_data.py
+++ b/etc/examples/tf-summary-model/input_data.py
@@ -3,8 +3,10 @@
 """Functions for downloading and reading MNIST data."""
 import gzip
 import os
+from six.moves import xrange
 from six.moves.urllib.request import urlretrieve
 import numpy
+
 
 def _read32(bytestream):
     dt = numpy.dtype(numpy.uint32).newbyteorder('>')

--- a/etc/examples/tf-summary-model/mnist_with_summaries.py
+++ b/etc/examples/tf-summary-model/mnist_with_summaries.py
@@ -25,8 +25,10 @@ from __future__ import division
 from __future__ import print_function
 
 import argparse
-import sys
+import itertools
 import os
+import re
+import sys
 
 import tensorflow as tf
 


### PR DESCRIPTION

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

Fix the following __undefined names__ in Python 3:

flake8 testing of https://github.com/IBM/FfDL on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./etc/examples/caffe2-model/mnist.py:453:23: F821 undefined name 'data_parallel_model_utils'
        activations = data_parallel_model_utils.GetActivationBlobs(train_model)
                      ^
./etc/examples/caffe2-model/mnist.py:454:9: F821 undefined name 'data_parallel_model_utils'
        data_parallel_model_utils.ShiftActivationDevices(
        ^
./etc/examples/tf-model/input_data.py:100:40: F821 undefined name 'xrange'
            fake_image = [1.0 for _ in xrange(784)]
                                       ^
./etc/examples/tf-model/input_data.py:102:41: F821 undefined name 'xrange'
            return [fake_image for _ in xrange(batch_size)], [
                                        ^
./etc/examples/tf-model/input_data.py:103:37: F821 undefined name 'xrange'
                fake_label for _ in xrange(batch_size)]
                                    ^
./etc/examples/tf-summary-model/input_data.py:99:40: F821 undefined name 'xrange'
            fake_image = [1.0 for _ in xrange(784)]
                                       ^
./etc/examples/tf-summary-model/input_data.py:101:41: F821 undefined name 'xrange'
            return [fake_image for _ in xrange(batch_size)], [
                                        ^
./etc/examples/tf-summary-model/input_data.py:102:37: F821 undefined name 'xrange'
                fake_label for _ in xrange(batch_size)]
                                    ^
./etc/examples/tf-summary-model/mnist_with_summaries.py:47:9: F821 undefined name 're'
    m = re.match(".*-([0-9]+)$", filename)
        ^
./etc/examples/tf-summary-model/mnist_with_summaries.py:58:23: F821 undefined name 'itertools'
        checkpoints = itertools.chain([cs.model_checkpoint_path], reversed(cs.all_model_checkpoint_paths))
                      ^
10    F821 undefined name 'data_parallel_model_utils'
10
```