### PR TITLE
Upgrade pip to remove insecure platform warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ before_script:
   - curl https://glide.sh/get | bash > /dev/null
   # install "nsenter" (needed for k8s container port forwarding)
   - docker run --rm jpetazzo/nsenter cat /nsenter > /tmp/nsenter 2> /dev/null; sudo cp /tmp/nsenter /usr/local/bin/; sudo chmod +x /usr/local/bin/nsenter; which nsenter
+  # upgrade requests[security] to remove insecure platform warnings
+  - pip install --user requests[security]
+  - sudo -H pip install requests[security]
   # install Minikube (in the background, to speed up the build)
   - make install-minikube-in-ci > /dev/null &
   # install Helm


### PR DESCRIPTION

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

Upgrade pip to avoid security warnings:
* https://travis-ci.org/IBM/FfDL/builds/370775534#L492-L527