### PR TITLE
Clarify Minikube's develop environment

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -16,6 +16,13 @@ Install:
 * `Go` is very specific about directory layouts. Make sure to set your `$GOPATH` and clone this repo to a directory
 `$GOPATH/src/github.com/IBM/FfDL` before proceeding with the next steps.
 
+> If you are developing on Minikube, please run the following commands to configure your Minikube and set up the Docker client to use the Minikube's Docker Daemon. Then start to build your own Docker images.
+> ```shell
+> export VM_TYPE=minikube
+> make minikube
+> eval $(minikube docker-env)
+> ```
+
 
 Then, fetch the dependencies via:
 ```


### PR DESCRIPTION
Since #65 will take a while to merge in, we need to clarify the Minikube's develop environment in Developer-guide.md to avoid confusion. 

This closes #56.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

