### PR TITLE
Revert #76 because the python3 dependency issue is fixed

### DIFF
--- a/metrics/log_collectors/emetrics_file/Dockerfile
+++ b/metrics/log_collectors/emetrics_file/Dockerfile
@@ -44,8 +44,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 3
 
-RUN apt-get install -y --no-install-recommends python3-distutils
-
 RUN update-alternatives --config python3
 
 RUN pip3 install --upgrade pip

--- a/metrics/log_collectors/regex_extractor/Dockerfile
+++ b/metrics/log_collectors/regex_extractor/Dockerfile
@@ -46,8 +46,6 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 3
 
 RUN update-alternatives --config python3
 
-RUN apt-get install -y --no-install-recommends python3-distutils
-
 RUN pip3 install --upgrade pip
 RUN pip3 install -U setuptools
 RUN pip3 install grpcio==1.7.3 python-dateutil pyyaml

--- a/metrics/log_collectors/simple_log_collector/Dockerfile
+++ b/metrics/log_collectors/simple_log_collector/Dockerfile
@@ -39,14 +39,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     musl-dev \
     "python3.6" \
-    python3-pip 
+    python3-pip
 
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 3
 
 RUN update-alternatives --config python3
-
-RUN apt-get install -y --no-install-recommends python3-distutils
 
 RUN pip3 install --upgrade pip
 RUN pip3 install grpcio==1.7.3 python-dateutil


### PR DESCRIPTION
Revert #76 because the python3 dependency issue is fixed and the extra library is making some duplication issue on Travis.

This reverts commit a18bde590b6d65afa2f8aa9b71bac84ed673351d.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

