### PR TITLE
Clean up and rearrange training instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To know more about the architectural details, please read [here](design/design_d
 
 * Follow the appropriate instructions for standing up your Kubernetes cluster using [IBM Cloud Public](https://github.com/IBM/container-journey-template/blob/master/README.md) or [IBM Cloud Private](https://github.com/IBM/deploy-ibm-cloud-private/blob/master/README.md)
 
-* The minimum recommended capacity for FfDL is 4GB Memory and 2 CPUs.
+* The minimum recommended capacity for FfDL is 4GB Memory and 3 CPUs.
 
 ## Usage Scenarios
 
@@ -223,7 +223,36 @@ do
 done
 ```
 
-4. Next, let's download all the necessary training and testing images in [LMDB format](https://en.wikipedia.org/wiki/Lightning_Memory-Mapped_Database) for our Caffe model
+4. Now you should have all the necessary training data set in your object storage. Let's go ahead to set up your restapi endpoint
+and default credentials for Deep Learning as a Service. Once you done that, you can start running jobs using the FfDL CLI (executable
+binary).
+
+```shell
+restapi_port=$(kubectl get service ffdl-restapi -o jsonpath='{.spec.ports[0].nodePort}')
+export DLAAS_URL=http://$node_ip:$restapi_port; export DLAAS_USERNAME=test-user; export DLAAS_PASSWORD=test;
+
+# Obtain the correct CLI for your machine and run the training job with our default TensorFlow model
+CLI_CMD=$(pwd)/cli/bin/ffdl-$(if [ "$(uname)" = "Darwin" ]; then echo 'osx'; else echo 'linux'; fi)
+$CLI_CMD train etc/examples/tf-model/manifest.yml etc/examples/tf-model
+```
+
+Congratulation, you had submitted your first job on FfDL. You can check your FfDL status either from the FfDL UI or simply run `$CLI_CMD list`
+
+> You can learn about how to create your own model definition files and `manifest.yaml` at [user guild](docs/user-guide.md#2-create-new-models-with-ffdl).
+
+5. If you want to run your job via the FfDL UI, simply run the below command to create your model zip file.
+
+```shell
+# Replace tf-model with the model you want to zip
+pushd etc/examples/tf-model && zip ../tf-model.zip * && popd
+```
+
+Then, upload `tf-model.zip` and `manifest.yml` (The default TensorFlow model) in the `etc/examples/` repository as shown below.
+Then, click `Submit Training Job` to run your job.
+
+![ui-example](docs/images/ui-example.png)
+
+6. (Optional) Since it's simple and straightforward to submit jobs with different deep learning framework on FfDL, let's try to run a Caffe Job. Download all the necessary training and testing images in [LMDB format](https://en.wikipedia.org/wiki/Lightning_Memory-Mapped_Database) for our Caffe model
 and upload those images to your mnist_lmdb_data bucket.
 
 ```shell
@@ -238,24 +267,7 @@ do
 done
 ```
 
-5. Now you should have all the necessary training data set in your object storage. Let's go ahead to set up your restapi endpoint
-and default credentials for Deep Learning as a Service. Once you done that, you can start running jobs using the FfDL CLI (executable
-binary).
-
-```shell
-restapi_port=$(kubectl get service ffdl-restapi -o jsonpath='{.spec.ports[0].nodePort}')
-export DLAAS_URL=http://$node_ip:$restapi_port; export DLAAS_USERNAME=test-user; export DLAAS_PASSWORD=test;
-
-# Obtain the correct CLI for your machine and run the training job with our default TensorFlow model
-CLI_CMD=cli/bin/ffdl-$(if [ "$(uname)" = "Darwin" ]; then echo 'osx'; else echo 'linux'; fi)
-$CLI_CMD train etc/examples/tf-model/manifest.yml etc/examples/tf-model
-```
-
-Congratulation, you had submitted your first job on FfDL. You can check your FfDL status either from the FfDL UI or simply run `$CLI_CMD list`
-
-> You can learn about how to create your own model definition files and `manifest.yaml` at [user guild](docs/user-guide.md#2-create-new-models-with-ffdl).
-
-6. Since it's simple and straightforward to submit jobs with different deep learning framework on FfDL, let's try to run a Caffe Job.
+7. Now train your Caffe Job.
 
 ```shell
 $CLI_CMD train etc/examples/caffe-model/manifest.yml etc/examples/caffe-model
@@ -265,18 +277,6 @@ Congratulation, now you know how to deploy jobs with different deep learning fra
 you can simply run `$CLI_CMD logs <MODEL_ID>`
 
 > If you no longer need any of the MNIST dataset we used in this example, you can simply delete the `tmp` repository.
-
-7. If you want to run your job via the FfDL UI, simply run the below command to create your model zip file.
-
-```shell
-# Replace tf-model with the model you want to zip
-pushd etc/examples/tf-model && zip ../tf-model.zip * && popd
-```
-
-Then, upload `tf-model.zip` and `manifest.yml` (The default TensorFlow model) in the `etc/examples/` repository as shown below.
-Then, click `Submit Training Job` to run your job.
-
-![ui-example](docs/images/ui-example.png)
 
 ### 6.2. Using Cloud Object Storage
 
@@ -373,6 +373,8 @@ helm delete $(helm list | grep ffdl | awk '{print $1}' | head -n 1)
   make sure to follow the standard Go directory layout (see [Prerequisites section]{#Prerequisites}).
 
 * To remove FfDL on your Cluster, simply run `make undeploy`
+
+* When using the FfDL CLI to train a model, make sure your directory path doesn't have backslash `/` at the end.
 
 ## 9. References
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ CLI_CMD=$(pwd)/cli/bin/ffdl-$(if [ "$(uname)" = "Darwin" ]; then echo 'osx'; els
 $CLI_CMD train etc/examples/tf-model/manifest.yml etc/examples/tf-model
 ```
 
-Congratulation, you had submitted your first job on FfDL. You can check your FfDL status either from the FfDL UI or simply run `$CLI_CMD list`
+Congratulations, you had submitted your first job on FfDL. You can check your FfDL status either from the FfDL UI or simply run `$CLI_CMD list`
 
 > You can learn about how to create your own model definition files and `manifest.yaml` at [user guild](docs/user-guide.md#2-create-new-models-with-ffdl).
 
@@ -273,7 +273,7 @@ done
 $CLI_CMD train etc/examples/caffe-model/manifest.yml etc/examples/caffe-model
 ```
 
-Congratulation, now you know how to deploy jobs with different deep learning framework. To learn more about your job execution results,
+Congratulations, now you know how to deploy jobs with different deep learning framework. To learn more about your job execution results,
 you can simply run `$CLI_CMD logs <MODEL_ID>`
 
 > If you no longer need any of the MNIST dataset we used in this example, you can simply delete the `tmp` repository.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -32,6 +32,7 @@ Currently, Fabric for Deep Learning supports following community frameworks
 | [pytorch](https://hub.docker.com/r/pytorch/pytorch/)       | v0.2, latest | CPU, GPU |
 | [caffe2](https://hub.docker.com/r/caffe2ai/caffe2/)        | c2v0.8.1.cpu.full.ubuntu14.04, c2v0.8.0.cpu.full.ubuntu16.04 | CPU |
 | [caffe2](https://hub.docker.com/r/caffe2ai/caffe2/)        | c2v0.8.1.cuda8.cudnn7.ubuntu16.04, latest | GPU |
+| [h2o3](https://hub.docker.com/r/opsh2oai/h2o3-ffdl/)    | latest | CPU |
 
 You can deploy models based on these frameworks and then train your models using the FfDL CLI or FfDL UI.
 


### PR DESCRIPTION
* Clean up and rearrange training instructions to avoid confusions.
* Change minikube's minimum recommended capacity to 3 CPUs to avoid bottleneck.
* Add H2O3 to the supported framework list in the user-guide.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

