### PR TITLE
Add new travis job for prebuilt images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,26 +27,12 @@ before_script:
   # install aws CLI
   - (sudo pip install -q awscli; which aws > /dev/null) &
 
-script:
-  # fail fast
-  - set -e
-  - export MAKE_ARGS=--no-print-directory
-  # Open SSH
-  #  - echo travis:$sshpassword | sudo chpasswd
-  #  - sudo sed -i 's/ChallengeResponseAuthentication no/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config
-  #  - sudo service ssh restart
-  #  - sudo apt-get install sshpass
-  #  - sshpass -p $sshpassword ssh -R 9999:localhost:22 -o StrictHostKeyChecking=no travis@$bouncehostip
-  # compile and build Docker images
-  - glide -q install
-  - make $MAKE_ARGS docker-build-base
-  - make $MAKE_ARGS gen-certs
-  - make $MAKE_ARGS build
-  - make $MAKE_ARGS docker-build
-  # deploy services
-  - make $MAKE_ARGS deploy
-  # submit a test job
-  - make $MAKE_ARGS test-submit-minikube-ci
+jobs:
+  include:
+    - stage: test
+      script: ./bin/travis_scripts/test-local-built-images.sh
+    - if: type IN (push, api, cron)
+      script: ./bin/travis_scripts/test-prebuilt-images.sh
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ CI_KUBECTL_VERSION ?= v1.9.4
 
 TRAVIS_IMAGE_VERSION ?= v0.1
 TEST_IMAGES = $(addprefix $(DOCKER_NAMESPACE)/, $(TEST_IMAGES_SUFFIX))
-TEST_IMAGES_SUFFIX = ffdl-lcm ffdl-trainer ffdl-metrics ffdl-databroker_s3 ffdl-ui ffdl-restapi ffdl-jobmonitor ffdl-controller log_collector ffdl-databroker_objectstorage tensorboard_extract
+TEST_IMAGES_SUFFIX = $(shell cat bin/ffdl-microservices.txt)
 
 AWS_ACCESS_KEY_ID ?= test
 AWS_SECRET_ACCESS_KEY ?= test
@@ -627,7 +627,8 @@ pull-prebuilt-images: $(addprefix pull-, $(TEST_IMAGES))
 $(addprefix pull-, $(TEST_IMAGES)): pull-%: %
 	@TRAVIS_IMAGE=$< make .pull-prebuilt-images
 
-$(TEST_IMAGES): ; # Make targets
+# Prebuilt images make targets
+$(TEST_IMAGES): ;
 
 .pull-prebuilt-images:
 	docker pull $(TRAVIS_IMAGE):$(TRAVIS_IMAGE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ PUBLIC_IP ?= 127.0.0.1
 CI_MINIKUBE_VERSION ?= v0.25.1
 CI_KUBECTL_VERSION ?= v1.9.4
 
+TRAVIS_IMAGE_VERSION ?= v0.1
+TEST_IMAGES = $(addprefix $(DOCKER_NAMESPACE)/, $(TEST_IMAGES_SUFFIX))
+TEST_IMAGES_SUFFIX = ffdl-lcm ffdl-trainer ffdl-metrics ffdl-databroker_s3 ffdl-ui ffdl-restapi ffdl-jobmonitor ffdl-controller log_collector ffdl-databroker_objectstorage tensorboard_extract
+
 AWS_ACCESS_KEY_ID ?= test
 AWS_SECRET_ACCESS_KEY ?= test
 
@@ -616,6 +620,17 @@ test-s3:
 	s3cmd="aws --endpoint-url=$$s3_url s3"; \
 	echo "s3cmd=$$s3cmd"; \
 	$$s3cmd ls
+
+pull-prebuilt-images:  ## Pull FfDL images from dockerhub
+pull-prebuilt-images: $(addprefix pull-, $(TEST_IMAGES))
+
+$(addprefix pull-, $(TEST_IMAGES)): pull-%: %
+	@TRAVIS_IMAGE=$< make .pull-prebuilt-images
+
+$(TEST_IMAGES): ; # Make targets
+
+.pull-prebuilt-images:
+	docker pull $(TRAVIS_IMAGE):$(TRAVIS_IMAGE_VERSION)
 
 
 .build-service:

--- a/bin/ffdl-microservices.txt
+++ b/bin/ffdl-microservices.txt
@@ -1,0 +1,11 @@
+ffdl-lcm
+ffdl-trainer
+ffdl-metrics
+ffdl-databroker_s3
+ffdl-ui
+ffdl-restapi
+ffdl-jobmonitor
+ffdl-controller
+log_collector
+ffdl-databroker_objectstorage
+tensorboard_extract

--- a/bin/travis_scripts/test-local-built-images.sh
+++ b/bin/travis_scripts/test-local-built-images.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# fail fast
+set -e
+export MAKE_ARGS=--no-print-directory
+# Open SSH
+#  - echo travis:$sshpassword | sudo chpasswd
+#  - sudo sed -i 's/ChallengeResponseAuthentication no/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config
+#  - sudo service ssh restart
+#  - sudo apt-get install sshpass
+#  - sshpass -p $sshpassword ssh -R 9999:localhost:22 -o StrictHostKeyChecking=no travis@$bouncehostip
+# compile and build Docker images
+glide -q install
+make $MAKE_ARGS docker-build-base
+make $MAKE_ARGS gen-certs
+make $MAKE_ARGS build
+make $MAKE_ARGS docker-build
+# deploy services
+make $MAKE_ARGS deploy
+# submit a test job
+make $MAKE_ARGS test-submit-minikube-ci

--- a/bin/travis_scripts/test-prebuilt-images.sh
+++ b/bin/travis_scripts/test-prebuilt-images.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# fail fast
+set -e
+export MAKE_ARGS=--no-print-directory
+# get pre-built images
+make $MAKE_ARGS pull-prebuilt-images
+export IMAGE_TAG=$TRAVIS_IMAGE_VERSION
+# deploy services
+make $MAKE_ARGS deploy
+# submit a test job
+make $MAKE_ARGS test-submit-minikube-ci


### PR DESCRIPTION
This is an updated PR for #49 
- Add a new Travis job to test DockerHub images and modify Travis to run 2 test jobs in parallel.
- Move the travis script commands under `bin/travis_scripts`.
- Closes #11 

Note: The new Travis job only checks pre-built images working on master branch but not pending PRs because any pending PRs changes will not be reflected in the pre-built images yet. But you can find a sample prebuilt images run of this PR at https://travis-ci.org/IBM/FfDL/builds/399363365
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

