### PR TITLE
Updates for seldon-core 0.2 release

### DIFF
--- a/community/FfDL-Seldon/pytorch-model/README.md
+++ b/community/FfDL-Seldon/pytorch-model/README.md
@@ -1,5 +1,10 @@
 # PyTorch MNIST Classifier
 
+# Assumptions
+
+ * You have installed [seldon-core](https://github.com/SeldonIO/seldon-core/blob/master/docs/install.md) on you FfDL cluster.
+
+
 # Train Model
 
 Train the [pyTorch MNIST model](https://github.com/IBM/FfDL/tree/master/etc/examples/pytorch-model) following the steps in the [user guide](https://github.com/IBM/FfDL#6-detailed-testing-instructions).

--- a/community/FfDL-Seldon/pytorch-model/ffdl-mnist-deployment.json
+++ b/community/FfDL-Seldon/pytorch-model/ffdl-mnist-deployment.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "machinelearning.seldon.io\/v1alpha1",
+  "apiVersion": "machinelearning.seldon.io\/v1alpha2",
   "kind": "SeldonDeployment",
   "metadata": {
     "labels": {
@@ -17,7 +17,7 @@
     "oauth_secret": "oauth-secret",
     "predictors": [
       {
-        "componentSpec": {
+        "componentSpecs": [{
           "spec": {
             "containers": [
               {
@@ -76,7 +76,7 @@
             ],
             "terminationGracePeriodSeconds": 20
           }
-        },
+        }],
         "graph": {
           "children": [],
           "name": "classifier",

--- a/community/FfDL-Seldon/pytorch-model/serving_ambassador.ipynb
+++ b/community/FfDL-Seldon/pytorch-model/serving_ambassador.ipynb
@@ -84,7 +84,7 @@
     "**Ensure you have port forwarded to the Ambassador pod:**\n",
     "\n",
     "```\n",
-    "kubectl port-forward $(kubectl get pods -n default -l service=ambassador -o jsonpath='{.items[0].metadata.name}') -n default 8002:80\n",
+    "kubectl port-forward $(kubectl get pods -n default -l service=ambassador -o jsonpath='{.items[0].metadata.name}') -n default 8002:8080\n",
     "```"
    ]
   },

--- a/community/FfDL-Seldon/tf-model/README.md
+++ b/community/FfDL-Seldon/tf-model/README.md
@@ -1,5 +1,9 @@
 # TensorFlow MNIST Classifier
 
+# Assumptions
+
+ * You have installed [seldon-core](https://github.com/SeldonIO/seldon-core/blob/master/docs/install.md) on you FfDL cluster.
+
 # Train Model
 
 Train the [Tensorflow MNIST model](https://github.com/IBM/FfDL/tree/master/etc/examples/tf-model) following the steps in the [user guide](https://github.com/IBM/FfDL#6-detailed-testing-instructions).

--- a/community/FfDL-Seldon/tf-model/ffdl-mnist-deployment.json
+++ b/community/FfDL-Seldon/tf-model/ffdl-mnist-deployment.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "machinelearning.seldon.io\/v1alpha1",
+  "apiVersion": "machinelearning.seldon.io\/v1alpha2",
   "kind": "SeldonDeployment",
   "metadata": {
     "labels": {
@@ -17,7 +17,7 @@
     "oauth_secret": "oauth-secret",
     "predictors": [
       {
-        "componentSpec": {
+        "componentSpecs": [{
           "spec": {
             "containers": [
               {
@@ -76,7 +76,7 @@
             ],
             "terminationGracePeriodSeconds": 20
           }
-        },
+        }],
         "graph": {
           "children": [],
           "name": "classifier",

--- a/community/FfDL-Seldon/tf-model/serving_ambassador.ipynb
+++ b/community/FfDL-Seldon/tf-model/serving_ambassador.ipynb
@@ -85,7 +85,7 @@
     "**Ensure you have port forwarded to the Ambassador pod:**\n",
     "\n",
     "```\n",
-    "kubectl port-forward $(kubectl get pods -n default -l service=ambassador -o jsonpath='{.items[0].metadata.name}') -n default 8002:80\n",
+    "kubectl port-forward $(kubectl get pods -n default -l service=ambassador -o jsonpath='{.items[0].metadata.name}') -n default 8002:8080\n",
     "```"
    ]
   },


### PR DESCRIPTION

 * Changed the deployment graphs so they work with the latest v1alpha2 CRD of seldon-core
 * Small update to jupyter notebooks for Ambassador which now runs on port 8080
 * Added links to seldon-core install docs from example READMEs
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

