### PR TITLE
Update deprecated framework versions

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -25,15 +25,15 @@ Currently, Fabric for Deep Learning supports following community frameworks
 
 | Framework     | Versions      | Processing Unit |
 | ------------- | ------------- | --------------- |
-| [tensorflow](https://hub.docker.com/r/tensorflow/tensorflow/)    | 1.3.0, 1.3.0-py3, 1.4.0, 1.4.0-py3, 1.5.0, 1.5.0-py3, 1.5.1, 1.5.1-py3, 1.6.0, 1.6.0-py3, 1.7.0, 1.7.0-py3, 1.8.0, 1.8.0-py3, latest, latest-py3 | CPU |
-| [tensorflow](https://hub.docker.com/r/tensorflow/tensorflow/)    | 1.3.0-gpu, 1.3.0-gpu-py3, 1.4.0-gpu, 1.4.0-gpu-py3, 1.5.0-gpu, 1.5.0-gpu-py3, 1.5.1-gpu, 1.5.1-gpu-py3, 1.6.0-gpu, 1.6.0-gpu-py3, 1.7.0-gpu, 1.7.0-gpu-py3, 1.8.0-gpu, 1.8.0-gpu-py3, latest-gpu, latest-gpu-py3 | GPU |
+| [tensorflow](https://hub.docker.com/r/tensorflow/tensorflow/)    | 1.4.0, 1.4.0-py3, 1.5.0, 1.5.0-py3, 1.5.1, 1.5.1-py3, 1.6.0, 1.6.0-py3, 1.7.0, 1.7.0-py3, 1.8.0, 1.8.0-py3, 1.9.0, 1.9.0-py3, latest, latest-py3 | CPU |
+| [tensorflow](https://hub.docker.com/r/tensorflow/tensorflow/)    | 1.4.0-gpu, 1.4.0-gpu-py3, 1.5.0-gpu, 1.5.0-gpu-py3, 1.5.1-gpu, 1.5.1-gpu-py3, 1.6.0-gpu, 1.6.0-gpu-py3, 1.7.0-gpu, 1.7.0-gpu-py3, 1.8.0-gpu, 1.8.0-gpu-py3, 1.9.0-gpu, 1.9.0-gpu-py3, latest-gpu, latest-gpu-py3 | GPU |
 | [caffe](https://hub.docker.com/r/bvlc/caffe/)         | cpu, intel   | CPU |
 | [caffe](https://hub.docker.com/r/bvlc/caffe/)         | gpu           | GPU |
 | [pytorch](https://hub.docker.com/r/pytorch/pytorch/)       | v0.2, latest | CPU, GPU |
 | [caffe2](https://hub.docker.com/r/caffe2ai/caffe2/)        | c2v0.8.1.cpu.full.ubuntu14.04, c2v0.8.0.cpu.full.ubuntu16.04 | CPU |
 | [caffe2](https://hub.docker.com/r/caffe2ai/caffe2/)        | c2v0.8.1.cuda8.cudnn7.ubuntu16.04, latest | GPU |
 | [h2o3](https://hub.docker.com/r/opsh2oai/h2o3-ffdl/)    | latest | CPU |
-| [horovod](https://hub.docker.com/r/uber/horovod/)       | 0.13.4-tf1.8.0-torch0.4.0-py3.5, 0.13.4-tf1.8.0-torch0.4.0-py2.7 | CPU, GPU |
+| [horovod](https://hub.docker.com/r/uber/horovod/)       | 0.13.10-tf1.9.0-torch0.4.0-py2.7, 0.13.10-tf1.9.0-torch0.4.0-py3.5 | CPU, GPU |
 
 You can deploy models based on these frameworks and then train your models using the FfDL CLI or FfDL UI.
 

--- a/etc/examples/horovod/manifest_pytorchmnist.yml
+++ b/etc/examples/horovod/manifest_pytorchmnist.yml
@@ -20,5 +20,5 @@ data_stores:
 
 framework:
   name: horovod
-  version: "0.13.4-tf1.8.0-torch0.4.0-py3.5"
+  version: "0.13.10-tf1.9.0-torch0.4.0-py3.5"
   command: python pytorch_mnist.py

--- a/etc/examples/horovod/manifest_tfmnist.yml
+++ b/etc/examples/horovod/manifest_tfmnist.yml
@@ -20,6 +20,6 @@ data_stores:
 
 framework:
   name: horovod
-  version: "0.13.4-tf1.8.0-torch0.4.0-py3.5"
+  version: "0.13.10-tf1.9.0-torch0.4.0-py3.5"
   command: python tensorflow_mnist.py
   # the command is basically running the above command via openmpi, feel free to remove  -x NCCL_DEBUG=INFO

--- a/templates/services/learner-configmap.yml
+++ b/templates/services/learner-configmap.yml
@@ -31,10 +31,10 @@ data:
   tensorflow_gpu_1.4.0-gpu_CURRENT: manual
   tensorflow_cpu_1.4.0_CURRENT: manual
   tensorflow_cpu_1.4.0-py3_CURRENT: manual
-  tensorflow_gpu_1.3.0-gpu-py3_CURRENT: manual
-  tensorflow_gpu_1.3.0-gpu_CURRENT: manual
-  tensorflow_cpu_1.3.0_CURRENT: manual
-  tensorflow_cpu_1.3.0-py3_CURRENT: manual
+  tensorflow_gpu_1.9.0-gpu-py3_CURRENT: manual
+  tensorflow_gpu_1.9.0-gpu_CURRENT: manual
+  tensorflow_cpu_1.9.0_CURRENT: manual
+  tensorflow_cpu_1.9.0-py3_CURRENT: manual
   h2o3_cpu_latest_CURRENT: manual
   caffe_cpu_cpu_CURRENT: master-39
   caffe_gpu_gpu_CURRENT: master-39
@@ -45,8 +45,8 @@ data:
   caffe2_gpu_c2v0.8.1.cuda8.cudnn7.ubuntu16.04_CURRENT: master-39
   caffe2_cpu_c2v0.8.0.cpu.full.ubuntu16.04_CURRENT: master-39
   caffe2_gpu_latest_CURRENT: master-39
-  horovod_gpu_0.13.4-tf1.8.0-torch0.4.0-py3.5_CURRENT: manual
-  horovod_gpu_0.13.4-tf1.8.0-torch0.4.0-py2.7_CURRENT: manual
+  horovod_gpu_0.13.10-tf1.9.0-torch0.4.0-py3.5_CURRENT: manual
+  horovod_gpu_0.13.10-tf1.9.0-torch0.4.0-py2.7_CURRENT: manual
 ---
 
 apiVersion: v1


### PR DESCRIPTION
Horovod and TensorFlow updated their community images on DockerHub and some of the old tags are deprecated. Hence, update the configmap with new image tags to prevent image pull error.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

