### PR TITLE
change Angular CLI global version to 6.0.8

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /ffdl/ffdl-dashboard
 RUN npm config set user 0
 RUN npm config set unsafe-perm true
 # install global dependencies
-RUN npm install --quiet -g @angular/cli
+RUN npm install --quiet -g @angular/cli@6.0.8
 RUN npm install --quiet -g http-server
 
 # set non-root user


### PR DESCRIPTION
The latest Angular CLI global version 6.1.1 removed some of the streaming function from the UI which break our current UI build and Travis.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

