### PR TITLE
Fix NAMESPACE typo on one of the deployment script

### DIFF
--- a/bin/create_static_volumes.sh
+++ b/bin/create_static_volumes.sh
@@ -13,7 +13,7 @@
 SHARED_VOLUME_STORAGE_CLASS="${SHARED_VOLUME_STORAGE_CLASS:-""}"
 
 volumeNum=${1:-1}
-Namespace=${Namespace:-default}
+NAMESPACE=${NAMESPACE:-default}
 
 echo "Creating persistent volume claim $volumeNum"
 (kubectl apply -f - <<EOF
@@ -21,7 +21,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: static-volume-$volumeNum
-  namespace: $Namespace
+  namespace: $NAMESPACE
   annotations:
     volume.beta.kubernetes.io/storage-class: "$SHARED_VOLUME_STORAGE_CLASS"
   labels:


### PR DESCRIPTION
There is a typo where we need to capitalize `NAMESPACE` on one of the deployment scripts. The bug only occurs when on a non-default namespace.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

