### PR TITLE
Use python zipfile instead of unzip shell command

### DIFF
--- a/lcm/service/lcm/container_helper.go
+++ b/lcm/service/lcm/container_helper.go
@@ -424,11 +424,12 @@ func constructLearnerContainer(req *service.JobDeploymentRequest, envVars []v1co
 	//FIXME need to have the learner IDs start from 1 rather than 0
 	var cmd string
 	var doCondExitWrite = true
+	//FIXME we assume all images has python installed to unzip the model.zip
 	if mountResultsStoreInLearner {
 		loadModelComand := `
 			echo "Starting Training $TRAINING_ID"
 			mkdir -p "$MODEL_DIR" ;
-			unzip -nq "$RESULT_DIR/_submitted_code/model.zip" -d "$MODEL_DIR"`
+			python -m zipfile -e $RESULT_DIR/_submitted_code/model.zip $MODEL_DIR `
 		learnerCommand := `
 			for i in ${!ALERTMANAGER*} ${!DLAAS*} ${!ETCD*} ${!GRAFANA*} ${!HOSTNAME*} ${!KUBERNETES*} ${!MONGO*} ${!PUSHGATEWAY*}; do unset $i; done;
 			export LEARNER_ID=$((${DOWNWARD_API_POD_NAME##*-} + 1)) ;


### PR DESCRIPTION
With the DLAAS June release, LCM assumes/requires all the learner images have bash unzip package which some community images such as PyTorch and Caffe don't come with it natively. Thus, as a work around, I changed the unzip command to use python `zipfile` because all our community images have python installed. However, we may need a better solution in the future where some images only have R or Julia for their runtimes.

@sboagibm what do you think? Thanks in advance.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

