### PR TITLE
ART notebook not rendered on GitHub

### DIFF
--- a/etc/notebooks/art/ART_model_robustness_check.ipynb
+++ b/etc/notebooks/art/ART_model_robustness_check.ipynb
@@ -837,7 +837,7 @@
       "53632/54000 [============================>.] - ETA: 1s - loss: 0.2848 - acc: 0.9115\n",
       "53760/54000 [============================>.] - ETA: 1s - loss: 0.2843 - acc: 0.9116\n",
       "53888/54000 [============================>.] - ETA: 0s - loss: 0.2839 - acc: 0.9118\n",
-      "54000/54000 [==============================] - 253s 5ms/step - loss: 0.2835 - acc: 0.9119 - val_loss: 0.0570 - val_acc: 0.9842\n"
+      "54000/54000 [==============================] - 253s 5ms/step - loss: 0.2835 - acc: 0.9119 - val_loss: 0.0570 - val_acc: 0.9842\n",
       "/usr/local/lib/python3.5/dist-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
       "  from ._conv import register_converters as _register_converters\n",
       "Using TensorFlow backend.\n",


### PR DESCRIPTION
When I last updated the notebook [ART_model_robustness_check.ipynb](https://github.com/IBM/FfDL/blob/master/etc/notebooks/art/ART_model_robustness_check.ipynb) I manually truncated the training log output, but I accidentally deleted one comma too many. As a result the notebook could not get rendered on GitHub.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

