### PR TITLE
Update instructions to always submit model definition files as zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,21 @@ To know more about the architectural details, please read the [design document](
 
 ## Usage Scenarios
 
-* If you have a FfDL deployment up and running, you can jump to [FfDL User Guide](docs/user-guide.md) to use FfDL for training your deep learning models.
+* **[FfDL User Guide](docs/user-guide.md)**: If you have a FfDL deployment up and running, you can jump to [FfDL User Guide](docs/user-guide.md) to use FfDL for training your deep learning models.
 
-* If you have FfDL confiugured to use GPUs, and want to train using GPUs, follow steps [here](docs/gpu-guide.md)
+* **[Training with GPUs](docs/gpu-guide.md)**: If you have FfDL configured to use GPUs, and want to train using GPUs, follow steps [here](docs/gpu-guide.md)
 
-* If you have used FfDL to train your models, and want to use a GPU enabled public cloud hosted service for further training and serving, please follow instructions [here](etc/converter/ffdl-wml.md) to train and serve your models using [Watson Studio Deep Learning](https://www.ibm.com/cloud/deep-learning) service.
+* **[Conversion from WML service](etc/converter/ffdl-wml.md)**: If you have used FfDL to train your models, and want to use a GPU enabled public cloud hosted service for further training and serving, please follow instructions [here](etc/converter/ffdl-wml.md) to train and serve your models using [Watson Studio Deep Learning](https://www.ibm.com/cloud/deep-learning) service.
 
-* If you are getting started and want to setup your own FfDL deployment, please follow the steps [below](#1-quick-start).
+* **[FfDL QuickStart](#1-quick-start)**: If you are getting started and want to setup your own FfDL deployment, please follow the steps [below](#1-quick-start).
 
-* If you want to leverage Jupyter notebooks to launch training on your FfDL cluster, please follow [these instructions](etc/notebooks/art)
+* **[leveraging with Jupyter notebooks](etc/notebooks/art)**: If you want to leverage Jupyter notebooks to launch training on your FfDL cluster, please follow [these instructions](etc/notebooks/art)
 
-* To invoke [Adversarial Robustness Toolbox](https://github.com/IBM/adversarial-robustness-toolbox) to find vulnerabilities in your models, follow the [instructions here](etc/notebooks/art)
+* **[Adversarial Robustness Toolbox Integration](etc/notebooks/art)**: To invoke [Adversarial Robustness Toolbox](https://github.com/IBM/adversarial-robustness-toolbox) to find vulnerabilities in your models, follow the [instructions here](etc/notebooks/art)
 
-* To deploy your trained models, follow [the integration guide with Seldon](community/FfDL-Seldon)
+* **[Model Deployment with Seldon](community/FfDL-Seldon)**: To deploy your trained models, follow [the integration guide with Seldon](community/FfDL-Seldon)
 
-* If you are looking for related collateral, slides, webinars, blogs and other materials related to FfDL, please [find them here](demos)
+* **[Demos and Publications](demos)**: If you are looking for related collateral, slides, webinars, blogs and other materials related to FfDL, please [find them here](demos)
 
 ## Steps
 
@@ -345,7 +345,7 @@ else
 fi
 ```
 
-7. Now train your Caffe Job.
+Now train your Caffe Job.
 
 ```shell
 $CLI_CMD train etc/examples/caffe-model/manifest-temp.yml etc/examples/caffe-model/zip

--- a/community/FfDL-H2Oai/README.md
+++ b/community/FfDL-H2Oai/README.md
@@ -64,19 +64,26 @@ restapi_port=$(kubectl get service ffdl-restapi -o jsonpath='{.spec.ports[0].nod
 export DLAAS_URL=http://$node_ip:$restapi_port; export DLAAS_USERNAME=test-user; export DLAAS_PASSWORD=test;
 ```
 
-Replace the default object storage path with your s3_url. You can skip this step if your already modified the object storage path with your s3_url.
+Create a temporary manifest file and replace the default object storage path with your s3_url. You can skip this step if your already modified the object storage path with your s3_url.
 ```shell
+cp community/FfDL-H2Oai/h2o-model/manifest-h2o.yml community/FfDL-H2Oai/h2o-model/manifest-h2o-temp.yml
 if [ "$(uname)" = "Darwin" ]; then
-  sed -i '' s/s3.default.svc.cluster.local/$node_ip:$s3_port/ community/FfDL-H2Oai/h2o-model/manifest-h2o.yml
+  sed -i '' s/s3.default.svc.cluster.local/$node_ip:$s3_port/ community/FfDL-H2Oai/h2o-model/manifest-h2o-temp.yml
 else
-  sed -i s/s3.default.svc.cluster.local/$node_ip:$s3_port/ community/FfDL-H2Oai/h2o-model/manifest-h2o.yml
+  sed -i s/s3.default.svc.cluster.local/$node_ip:$s3_port/ community/FfDL-H2Oai/h2o-model/manifest-h2o-temp.yml
 fi
+```
+
+Now, put all your model definition files into a zip file.
+```shell
+# Replace tf-model with the model you want to zip
+pushd community/FfDL-H2Oai/h2o-model && zip ../h2o-model.zip * && popd
 ```
 
 Obtain the correct CLI for your machine and run the training job with our default H2O model
 ```shell
 CLI_CMD=$(pwd)/cli/bin/ffdl-$(if [ "$(uname)" = "Darwin" ]; then echo 'osx'; else echo 'linux'; fi)
-$CLI_CMD train community/FfDL-H2Oai/h2o-model/manifest-h2o.yml community/FfDL-H2Oai/h2o-model
+$CLI_CMD train community/FfDL-H2Oai/h2o-model/manifest-h2o-temp.yml community/FfDL-H2Oai/h2o-model.zip
 ```
 
 Congratulations, you had submitted your first H2O job on FfDL. You can check your FfDL status either from the FfDL UI or simply run `$CLI_CMD list`

--- a/demos/fashion-mnist-training/fashion-train/README.md
+++ b/demos/fashion-mnist-training/fashion-train/README.md
@@ -64,9 +64,8 @@ Create a .yml file with the necessary information. manifest.yml has further inst
 We will now go back to this directory and deploy our training job to FfDL using the path to the .yml and path to the folder containing the experiment.py
 ```bash
 cd <path to this demo repo>/fashion-train
-# Replace manifest.yml with the path to your .yml file
-# Replace Image with the path to the folder containing your file created in step 6
-$CLI_CMD train manifest.yml fashion-training
+pushd fashion-training && zip ../fashion-training.zip * && popd # Put all your model definition files into a zip file.
+$CLI_CMD train manifest.yml fashion-training.zip # Replace manifest.yml and fashion-training.zip with the path to your .yml and .zip files
 ```
 ## Step 3b - Deploying the training job to FfDL using the FfDL UI
 
@@ -74,7 +73,7 @@ Alternatively, the FfDL UI can be used to deploy jobs. First zip your model.
 ```bash
 # Replace fashion-training with the path to your training file folder
 # Replace fashion-training.zip with the path where you want the .zip file stored
-pushd fashion-training && zip fashion-training * && popd
+pushd fashion-training && zip ../fashion-training * && popd
 ```
 
 Go to FfDL web UI. Upload the .zip to "Choose model definition zip to upload". Upload the .yml to "Choose manifest to upload". Then click Submit Training Job.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -95,7 +95,7 @@ Here are the [example manifest files](../etc/examples/tf-model/manifest.yml) for
 
 ### 2.5. Creating Model zip file
 
-You need to zip all the model definition files and create a model zip file for jobs submitting on FfDL UI. At present, FfDL UI only supports zip format for model files, other compression formats like gzip, bzip, tar etc., are not supported. **Note** that all model definition files has to be in the first level of the zip file and there are no nested directories in the zip file.
+You need to zip all the model definition files and create a model zip file for jobs submitting on FfDL. At present, FfDL only supports zip format for model files, other compression formats like gzip, bzip, tar etc., are not supported. **Note** that all model definition files has to be in the first level of the zip file and there are no nested directories in the zip file.
 
 ### 2.6. Model Deployment and Training
 After creating the manifest file and model definition file, you can either use the FfDL CLI or FfDL UI to deploy your model.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -94,7 +94,6 @@ Here are the [example manifest files](../etc/examples/tf-model/manifest.yml) for
       --test_images_file ${DATA_DIR}/t10k-images-idx3-ubyte.gz
 
 ### 2.5. Creating Model zip file
-**Note** that FfDL CLI can take both zip or unzip files.
 
 You need to zip all the model definition files and create a model zip file for jobs submitting on FfDL UI. At present, FfDL UI only supports zip format for model files, other compression formats like gzip, bzip, tar etc., are not supported. **Note** that all model definition files has to be in the first level of the zip file and there are no nested directories in the zip file.
 


### PR DESCRIPTION
Since DLaaS make a lots of improvements that assume users package their model definition files as zip, submitting model definition files without packaging sometimes will introduce some packaging errors. Thus, changing the training instructions to always package the model files into a zip file.
 
Also changing some minor formatting on the main README.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

