### PR TITLE
Update statsd flags with double dashes

### DIFF
--- a/templates/monitoring/pushgateway-deployment.yml
+++ b/templates/monitoring/pushgateway-deployment.yml
@@ -29,7 +29,7 @@ spec:
         - containerPort: 9125
           protocol: UDP
         args:
-         - '-statsd.mapping-config=/etc/statsd/mapping.conf'
+         - '--statsd.mapping-config=/etc/statsd/mapping.conf'
         volumeMounts:
         - name: statsd-volume
           mountPath: /etc/statsd


### PR DESCRIPTION
The latest statsd image (updated 2 days ago) now only accepts their flag inputs when using double dashes. Thus, we need to update the arguments to prevent the push-gateway and other dependent pods to crash.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

