### PR TITLE
Fashion-demo: Make model file name configurable in seldon-deployment

### DIFF
--- a/demos/fashion-mnist-training/seldon-deployment/MyModel.py
+++ b/demos/fashion-mnist-training/seldon-deployment/MyModel.py
@@ -13,6 +13,7 @@ class MyModel(object):
         bucket_name = os.environ.get("BUCKET_NAME")
         bucket_key = os.environ.get("BUCKET_KEY")
         bucket_secret = os.environ.get("BUCKET_SECRET")
+        model_file_name = os.environ.get("MODEL_FILE_NAME", "model.h5")
         print("Training id:{} endpoint URL:{} key:{} secret:{} bucket name:{}".format(training_id,endpoint_url,bucket_key,bucket_secret,bucket_name))
 
         # Define S3 resource and download the model file
@@ -23,10 +24,11 @@ class MyModel(object):
             aws_secret_access_key=bucket_secret,
         )
 
-        KEY = training_id + '/model.h5' # replace with your object key
+        KEY = training_id + '/' + model_file_name
+        model_path = 'model.h5'
 
         try:
-            client.Bucket(bucket_name).download_file(KEY, 'model.h5')
+            client.Bucket(bucket_name).download_file(KEY, model_path)
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == "404":
                 print("The object does not exist.")
@@ -34,7 +36,6 @@ class MyModel(object):
                 raise
 
         # Replace with path of trained model
-        model_path = 'model.h5'
         self.model = load_model(model_path)
 
     def predict(self,X,features_names):

--- a/demos/fashion-mnist-training/seldon-deployment/fashion-seldon.json
+++ b/demos/fashion-mnist-training/seldon-deployment/fashion-seldon.json
@@ -31,6 +31,10 @@
                 },
                 "env": [
                   {
+                    "name": "MODEL_FILE_NAME",
+                    "value": "model.h5"
+                  },
+                  {
                     "name": "TRAINING_ID",
                     "value": "<TRAINING_ID>"
                   },


### PR DESCRIPTION
With the model file name being configurable it is possible to re-use
the seldon-deployment part of the fashion demo for other models.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

