### PR TITLE
Travis CI: lint Python for syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
+language: python
+python: 3.6
 sudo: required
 
-branches:
-  only:
-    - master
+#branches:
+#  only:
+#    - master
 
 services:
   - docker
@@ -11,6 +13,9 @@ env:
   - CHANGE_MINIKUBE_NONE_USER=true
 
 before_script:
+  # lint Python for syntax errors and undefined names
+  - pip install flake8
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # install Go
   - (sudo add-apt-repository -y ppa:gophers/archive; sudo apt-get -y update; sudo apt-get -y install golang-1.9-go) > /dev/null 2>&1
   - export PATH=/usr/lib/go-1.9/bin:$PATH; export GOROOT=/usr/lib/go-1.9/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 python: 3.6
 sudo: required
 
-#branches:
-#  only:
-#    - master
+branches:
+  only:
+    - master
 
 services:
   - docker

--- a/etc/examples/c10d-dist-onnx/model-files/train_dist_onnx.py
+++ b/etc/examples/c10d-dist-onnx/model-files/train_dist_onnx.py
@@ -117,7 +117,7 @@ def run(rank, size, batch_size, is_gpu):
             if not (size == 1):
                 average_gradients(model)
             optimizer.step()
-        print('Process ', rank=dist.get_rank(),
+        print('Process ', dist.get_rank(),
               ', epoch ', epoch, '. avg_loss: ',
               epoch_loss / len(train_set))
 

--- a/etc/examples/c10d-onnx-mpi/model-files/train_dist_onnx_mpi.py
+++ b/etc/examples/c10d-onnx-mpi/model-files/train_dist_onnx_mpi.py
@@ -90,7 +90,7 @@ def run(rank, size, batch_size, is_gpu):
     test_set = torch.utils.data.DataLoader(
         test_set, batch_size=batch_size, shuffle=True, pin_memory=True)
 
-    num_batches = ceil(len(train_set.dataset) / float(bsz))
+    num_batches = ceil(len(train_set.dataset) / float(batch_size))
     # To train model
     model.train()
     for epoch in range(100):


### PR DESCRIPTION
In Travis CI, add a Python linting step that runs [flake8](http://flake8.pycqa.org) to find syntax errors and undefined names.

[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM/FfDL on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./etc/examples/c10d-onnx-mpi/model-files/train_dist_onnx_mpi.py:93:55: F821 undefined name 'bsz'
    num_batches = ceil(len(train_set.dataset) / float(bsz))
                                                      ^
./etc/examples/c10d-dist-onnx/model-files/train_dist_onnx.py:121:14: E999 SyntaxError: positional argument follows keyword argument
              ', epoch ', epoch, '. avg_loss: ',
             ^
1     E999 SyntaxError: positional argument follows keyword argument
1     F821 undefined name 'bsz'
2
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

