### PR TITLE
Update dind port forward script to be compatible with K8S client 1.9.x and 1.8.x

### DIFF
--- a/bin/dind-port-forward.sh
+++ b/bin/dind-port-forward.sh
@@ -5,7 +5,7 @@ s3_port=$(kubectl get service s3 -o jsonpath='{.spec.ports[0].nodePort}')
 ui_pod=$(kubectl get pods | grep ffdl-ui | awk '{print $1}')
 restapi_pod=$(kubectl get pods | grep ffdl-restapi | awk '{print $1}')
 grafana_pod=$(kubectl get pods | grep prometheus | awk '{print $1}')
-kubectl port-forward pod/$ui_pod $ui_port:8080 &
-kubectl port-forward pod/$restapi_pod $restapi_port:8080 &
-kubectl port-forward pod/$grafana_pod $grafana_port:3000 &
-kubectl port-forward pod/storage-0 $s3_port:4572 &
+kubectl port-forward $ui_pod $ui_port:8080 &
+kubectl port-forward $restapi_pod $restapi_port:8080 &
+kubectl port-forward $grafana_pod $grafana_port:3000 &
+kubectl port-forward storage-0 $s3_port:4572 &


### PR DESCRIPTION
The official default DIND instructions still pointing the K8S 1.8.x client which is not compatible with our current DIND port forward script. Thus, update the script to be backward compatible until K8S 1.9.x is deprecated.

Related issue #149 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

